### PR TITLE
Protect against arrays that can get passed as keys

### DIFF
--- a/src/PersistentRepository.php
+++ b/src/PersistentRepository.php
@@ -437,6 +437,10 @@ class PersistentRepository implements ArrayAccess, RepositoryContract
      */
     private function isPersistentKey($key): bool
     {
+        if (is_array($key)) {
+            $key = \array_key_first($key);
+        }
+
         foreach ($this->getItemKeys() as $persistentKey) {
             $key = $key.'.';
             $persistentKey = $persistentKey.'.';


### PR DESCRIPTION
Sometimes a key to be parsed might actually be an array. For testing in `isPersistentKey`, we need to protect against `Array to String conversion` errors.

The simplest way for that is to use [`array_key_first()`](https://www.php.net/manual/en/function.array-key-first.php), which exists in PHP 7.3